### PR TITLE
Update zone.xml.erb

### DIFF
--- a/templates/zone.xml.erb
+++ b/templates/zone.xml.erb
@@ -10,7 +10,7 @@
   <interface name="<%= interface %>"/>
 <%- end -%>
 <%- @sources.each do |source| -%>
-  <source name="<%= source %>"/>
+  <source address="<%= source %>"/>
 <%- end -%>
 <%- @services.each do |service| -%>
   <service name="<%= service %>"/>


### PR DESCRIPTION
The syntax for  'firewall-cmd --zone=$zone --add-source=[address/mask]' requires you add lines of the form '<source address="[address/mask]" />' to the zone.xml file under /etc/firewalld/zones/. 
This patch makes firewalld understand the zone.xml file as intended.
