### PR TITLE
fix rich_rules unnecesarry notifications

### DIFF
--- a/lib/puppet/provider/firewalld_rich_rule/ruleprovider.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/ruleprovider.rb
@@ -174,4 +174,161 @@ Puppet::Type.type(:firewalld_rich_rule).provide :ruleprovider do
         end
         return false
     end
+
+    # rich_rules getter
+    def rich_rules
+      path = '/etc/firewalld/zones/' + @resource[:zone] + '.xml'
+
+
+      zonename = File.basename(path, ".xml")
+      doc = REXML::Document.new File.read(path)
+      rich_rules = []
+
+      # Loop through the zone elements
+      doc.elements.each("zone/*") do |e|
+ 
+        if e.name == 'rule'
+
+            rule_source = {}
+            rule_destination = {}
+            rule_service = ''
+            rule_ports = {}
+            rule_protocol = ''
+            rule_icmp_blocks = ''
+            rule_masquerade = false
+            rule_forward_ports = {}
+            rule_log = {}
+            rule_audit = {}
+            rule_action = {}
+            rule_family = 'ipv4'
+
+          e.elements.each do |rule|
+            if rule.name == 'source'
+              rule_source['address'] = rule.attributes["address"]
+              if rule.attributes["invert"] == 'true'
+                rule_source['invert'] = true
+              else
+                rule_source['invert'] = rule.attributes["invert"].nil? ? nil : false
+              end
+              rule_source.delete_if { |key,value| key == 'invert' and value == nil}
+
+            end
+            if rule.name == 'destination'
+              rule_destination['address'] = rule.attributes["address"]
+              if rule.attributes["invert"] == 'true'
+                rule_destination['invert'] = true
+              else
+                rule_destination['invert'] = rule.attributes["invert"].nil? ? nil : false
+              end
+              rule_destination.delete_if { |key,value| key == 'invert' and value == nil}
+            end
+            if rule.name == 'service'
+              rule_service = rule.attributes["name"]
+            end
+            if rule.name == 'port'
+              rule_ports['portid'] = rule.attributes["port"].nil? ? nil : rule.attributes["port"]
+              rule_ports['protocol'] = rule.attributes["protocol"].nil? ? nil : rule.attributes["protocol"]
+            end
+            if rule.name == 'protocol'
+              rule_protocol = rule.attributes["value"]
+            end
+            if rule.name == 'icmp-block'
+              rule_icmp_blocks = rule.attributes["name"]
+            end
+            if rule.name == 'masquerade'
+              rule_masquerade = true
+            end
+            if rule.name == 'forward-port'
+              rule_forward_ports['portid'] = rule.attributes["port"].nil? ? nil : rule.attributes["port"]
+              rule_forward_ports['protocol'] = rule.attributes["protocol"].nil? ? nil : rule.attributes["protocol"]
+              rule_forward_ports['to_port'] = rule.attributes["to-port"].nil? ? nil : rule.attributes["to-port"]
+              rule_forward_ports['to_addr'] = rule.attributes["to-addr"].nil? ? nil : rule.attributes["to-addr"]
+            end
+            if rule.name == 'log'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_log['prefix'] = rule.attributes["prefix"].nil? ? nil : rule.attributes["prefix"]
+              rule_log['level'] = rule.attributes["level"].nil? ? nil : rule.attributes["level"]
+              rule_log['limit'] = limit
+            end
+            if rule.name == 'audit'
+              rule_audit ['limit'] = rule.elements["limit"].attributes["value"].nil? ? nil : rule.elements["limit"].attributes["value"]
+            end
+            if rule.name == 'accept'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_action['action_type'] = rule.name
+              rule_action['reject_type'] = nil
+              rule_action['limit'] = limit
+            end
+            if rule.name == 'reject'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_action['action_type'] = rule.name
+              rule_action['reject_type'] = rule.attributes["type"].nil? ? nil : rule.attributes["type"]
+              rule_action['limit']  = limit
+            end
+            if rule.name == 'drop'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_action['action_type'] = rule.name
+              rule_action['reject_type'] = nil
+              rule_action['limit']  = limit
+            end
+            if rule.name == 'family'
+              rule_family = rule.attributes["type"].nil? ? nil : rule.attributes["family"]
+            end
+          end
+          rich_rules << {
+            'source'        => rule_source.empty? ? nil : rule_source,
+            'destination'   => rule_destination.empty? ? nil : rule_destination,
+            'service'      => rule_service.empty? ? nil : rule_service,
+            'port'          => rule_ports.empty? ? nil : rule_ports,
+            'protocol'      => rule_protocol.empty? ? nil : rule_protocol,
+            'icmp_block'   => rule_icmp_blocks.empty? ? nil : rule_icmp_blocks,
+            'masquerade'    => rule_masquerade.nil? ? nil : rule_masquerade,
+            'forward_port' => rule_forward_ports.empty? ? nil : rule_forward_ports,
+            'log'         => rule_log.empty? ? nil : rule_log,
+            'audit'         => rule_audit.empty? ? nil : rule_audit,
+            'action'        => rule_action.empty? ? nil : rule_action,
+            'family'        => rule_family.empty? ? nil : rule_family,
+           }
+
+           # remove services if not set so the data type matches the data type returned by the puppet resource.
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'service' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'forward_port' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'protocol' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'icmp_block' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'masquerade' and value == false} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'audit' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'log' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'destination' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'source' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'port' and value == nil} }
+           
+           rich_rules.each { |rr| 
+             if rr["action"]
+               rr["action"].delete_if {|key,value| key == 'limit' and value == nil} 
+               rr["action"].delete_if {|key,value| key == 'reject_type' and value == nil} 
+             end
+             if rr["forward_port"]
+               rr["forward_port"].delete_if {|key,value| key == 'to_addr' and value == nil}
+             end
+           }
+        end
+      end
+      rich_rules
+    end
 end

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -73,6 +73,23 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
               limit       => string, optional
             }
       EOT
+
+      def insync?(is)
+        def itos(h)
+          h.each { |key, value|
+            h[key] = itos(value) if value.is_a?(Hash)
+            h[key] = value.to_s if value.is_a?(Integer)
+          }
+        end
+        if is.is_a?(Array) and @should.is_a?(Array)
+          @should.each { |should_el| 
+            itos(should_el) 
+            break unless is.detect { |is_el| is_el == should_el } 
+          }
+        else
+          is == @should
+        end
+      end
   end
 
 end


### PR DESCRIPTION
With local apply the puppet run will be ok, but on a puppetmaster firewalld_rich_rules keep on notifying the other resources even when they apear to be in sync. I've added a getter method on the provider and a insync method on the type for prefetching. This way the puppetmaster is able to prefetch so it will not trigger the events for the unnecesarry notifications.