### PR TITLE
Major update on module

### DIFF
--- a/lib/puppet/provider/firewalld_rich_rule/ruleprovider.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/ruleprovider.rb
@@ -174,4 +174,160 @@ Puppet::Type.type(:firewalld_rich_rule).provide :ruleprovider do
         end
         return false
     end
+    # rich_rules getter
+    def rich_rules
+      path = '/etc/firewalld/zones/' + @resource[:zone] + '.xml'
+
+
+      zonename = File.basename(path, ".xml")
+      doc = REXML::Document.new File.read(path)
+      rich_rules = []
+
+      # Loop through the zone elements
+      doc.elements.each("zone/*") do |e|
+ 
+        if e.name == 'rule'
+
+            rule_source = {}
+            rule_destination = {}
+            rule_service = ''
+            rule_ports = {}
+            rule_protocol = ''
+            rule_icmp_blocks = ''
+            rule_masquerade = false
+            rule_forward_ports = {}
+            rule_log = {}
+            rule_audit = {}
+            rule_action = {}
+            rule_family = 'ipv4'
+
+          e.elements.each do |rule|
+            if rule.name == 'source'
+              rule_source['address'] = rule.attributes["address"]
+              if rule.attributes["invert"] == 'true'
+                rule_source['invert'] = true
+              else
+                rule_source['invert'] = rule.attributes["invert"].nil? ? nil : false
+              end
+              rule_source.delete_if { |key,value| key == 'invert' and value == nil}
+
+            end
+            if rule.name == 'destination'
+              rule_destination['address'] = rule.attributes["address"]
+              if rule.attributes["invert"] == 'true'
+                rule_destination['invert'] = true
+              else
+                rule_destination['invert'] = rule.attributes["invert"].nil? ? nil : false
+              end
+              rule_destination.delete_if { |key,value| key == 'invert' and value == nil}
+            end
+            if rule.name == 'service'
+              rule_service = rule.attributes["name"]
+            end
+            if rule.name == 'port'
+              rule_ports['portid'] = rule.attributes["port"].nil? ? nil : rule.attributes["port"]
+              rule_ports['protocol'] = rule.attributes["protocol"].nil? ? nil : rule.attributes["protocol"]
+            end
+            if rule.name == 'protocol'
+              rule_protocol = rule.attributes["value"]
+            end
+            if rule.name == 'icmp-block'
+              rule_icmp_blocks = rule.attributes["name"]
+            end
+            if rule.name == 'masquerade'
+              rule_masquerade = true
+            end
+            if rule.name == 'forward-port'
+              rule_forward_ports['portid'] = rule.attributes["port"].nil? ? nil : rule.attributes["port"]
+              rule_forward_ports['protocol'] = rule.attributes["protocol"].nil? ? nil : rule.attributes["protocol"]
+              rule_forward_ports['to_port'] = rule.attributes["to-port"].nil? ? nil : rule.attributes["to-port"]
+              rule_forward_ports['to_addr'] = rule.attributes["to-addr"].nil? ? nil : rule.attributes["to-addr"]
+            end
+            if rule.name == 'log'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_log['prefix'] = rule.attributes["prefix"].nil? ? nil : rule.attributes["prefix"]
+              rule_log['level'] = rule.attributes["level"].nil? ? nil : rule.attributes["level"]
+              rule_log['limit'] = limit
+            end
+            if rule.name == 'audit'
+              rule_audit ['limit'] = rule.elements["limit"].attributes["value"].nil? ? nil : rule.elements["limit"].attributes["value"]
+            end
+            if rule.name == 'accept'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_action['action_type'] = rule.name
+              rule_action['reject_type'] = nil
+              rule_action['limit'] = limit
+            end
+            if rule.name == 'reject'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_action['action_type'] = rule.name
+              rule_action['reject_type'] = rule.attributes["type"].nil? ? nil : rule.attributes["type"]
+              rule_action['limit']  = limit
+            end
+            if rule.name == 'drop'
+              begin
+                limit = rule.elements["limit"].attributes["value"]
+              rescue
+                limit = nil
+              end
+              rule_action['action_type'] = rule.name
+              rule_action['reject_type'] = nil
+              rule_action['limit']  = limit
+            end
+            if rule.name == 'family'
+              rule_family = rule.attributes["family"].nil? ? nil : rule.attributes["family"]
+            end
+          end
+          rich_rules << {
+            'source'        => rule_source.empty? ? nil : rule_source,
+            'destination'   => rule_destination.empty? ? nil : rule_destination,
+            'service'      => rule_service.empty? ? nil : rule_service,
+            'port'          => rule_ports.empty? ? nil : rule_ports,
+            'protocol'      => rule_protocol.empty? ? nil : rule_protocol,
+            'icmp_block'   => rule_icmp_blocks.empty? ? nil : rule_icmp_blocks,
+            'masquerade'    => rule_masquerade.nil? ? nil : rule_masquerade,
+            'forward_port' => rule_forward_ports.empty? ? nil : rule_forward_ports,
+            'log'         => rule_log.empty? ? nil : rule_log,
+            'audit'         => rule_audit.empty? ? nil : rule_audit,
+            'action'        => rule_action.empty? ? nil : rule_action,
+            'family'        => rule_family.empty? ? nil : rule_family,
+           }
+
+           # remove services if not set so the data type matches the data type returned by the puppet resource.
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'service' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'forward_port' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'protocol' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'icmp_block' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'masquerade' and value == false} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'audit' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'log' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'destination' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'source' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'port' and value == nil} }
+           
+           rich_rules.each { |rr| 
+             if rr["action"]
+               rr["action"].delete_if {|key,value| key == 'limit' and value == nil} 
+               rr["action"].delete_if {|key,value| key == 'reject_type' and value == nil} 
+             end
+             if rr["forward_port"]
+               rr["forward_port"].delete_if {|key,value| key == 'to_addr' and value == nil}
+             end
+           }
+        end
+      end
+      rich_rules
+    end
 end

--- a/lib/puppet/provider/firewalld_zone/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zone/zoneprovider.rb
@@ -312,9 +312,9 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
             if rule.name == 'source'
               rule_source['address'] = rule.attributes["address"]
               if rule.attributes["invert"] == 'true'
-                rule_source['invert'] = true
+                rule_source['invert'] = 'true'
               else
-                rule_source['invert'] = rule.attributes["invert"].nil? ? nil : false
+                rule_source['invert'] = rule.attributes["invert"].nil? ? nil : 'false'
               end
               rule_source.delete_if { |key,value| key == 'invert' and value == nil}
 

--- a/lib/puppet/provider/firewalld_zone/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zone/zoneprovider.rb
@@ -4,200 +4,255 @@ require 'rexml/document'
 include REXML
 
 Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Provider::Firewalld do
-    @doc = "The zone config manipulator"
+  @doc = "The zone config manipulator"
 
-    commands :firewall => 'firewall-cmd'
+  commands :firewall => 'firewall-cmd'
 
-    mk_resource_methods
+  mk_resource_methods
 
-    def flush
-        Puppet.debug "firewalld zone provider: flushing (#{@resource[:name]})"
-	write_zonefile
-    end
+  def flush
+      Puppet.debug "firewalld zone provider: flushing (#{@resource[:name]})"
+	    write_zonefile
+  end
 
-    def create
-        Puppet.debug "firewalld zone provider: create (#{@resource[:name]})"
-	write_zonefile
-    end
+  def create
+      Puppet.debug "firewalld zone provider: create (#{@resource[:name]})"
+	    write_zonefile
+  end
 
-    def write_zonefile
-        Puppet.debug "firewalld zone provider: write_zonefile (#{@resource[:name]})"
-        doc = REXML::Document.new
-        zone = doc.add_element 'zone'
-        doc << REXML::XMLDecl.new(version='1.0',encoding='utf-8')
+  def write_zonefile
+      Puppet.debug "firewalld zone provider: write_zonefile (#{@resource[:name]})"
+      doc = REXML::Document.new
+      zone = doc.add_element 'zone'
+      doc << REXML::XMLDecl.new(version='1.0',encoding='utf-8')
 
-        if @resource[:target]
-          zone.add_attribute('target', @resource[:target])
+      if @resource[:target]
+        zone.add_attribute('target', @resource[:target])
+      end
+
+      if @resource[:short]
+        short = zone.add_element 'short'
+        short.text = @resource[:short]
+      end
+
+      if @resource[:description]
+        description = zone.add_element 'description'
+        description.text = @resource[:description]
+      end
+
+      if @resource[:interfaces]
+        @resource[:interfaces].each do |interface|
+          # TODO: firewall-cmd --get-zone-of-interface...
+          #Puppet.debug "1 doing a pre-get of zone of interface..."
+          #firewall('--zone='+@resource[:name]+' --change-interface='+interface)
+          #firewall('--permanent --zone='+@resource[:name]+' --change-interface='+interface)
+          #zoneofinterfacee = exec_firewall('--get-zone-of-interface',interface)
+          #puts zoneofinterfacee
+          
+          Puppet.debug "should be switching interface to zone..."
+          begin
+            zoneofinterface = exec_firewall('--get-zone-of-interface',interface)
+            if (zoneofinterface.strip != @resource[:name])
+              exec_firewall('--permanent','--zone',zoneofinterface.strip,'--remove-interface',interface)
+              exec_firewall('--zone',@resource[:name],'--change-interface',interface)
+            end
+          rescue Exception => bang
+            #puts bang.message
+          end
+
+          iface = zone.add_element 'interface'
+          iface.add_attribute('name', interface)
         end
+      end
 
-        if @resource[:short]
-          short = zone.add_element 'short'
-          short.text = @resource[:short]
+      if @resource[:sources]
+        @resource[:sources].each do |source|
+          # TODO: firewall-cmd --get-zone-of-source...
+          src = zone.add_element 'source'
+          src.add_attribute('address', source)
         end
+      end
 
-        if @resource[:description]
-          description = zone.add_element 'description'
-          description.text = @resource[:description]
+      if @resource[:services]
+        @resource[:services].each do |service|
+          srv = zone.add_element 'service'
+          srv.add_attribute('name', service)
+          Puppet.debug "firewalld zone provider: adding service (#{service}) to zone"
         end
+      end
 
-        if @resource[:interfaces]
-          @resource[:interfaces].each do |interface|
-            # TODO: firewall-cmd --get-zone-of-interface...
-            iface = zone.add_element 'interface'
-            iface.add_attribute('name', interface)
+      if @resource[:ports]
+        @resource[:ports].each do |port|
+          prt = zone.add_element 'port'
+          prt.add_attribute('port', port['port'])
+          prt.add_attribute('protocol', port['protocol'])
+        end
+      end
+
+      if @resource[:icmp_blocks]
+        @resource[:icmp_blocks].each do |icmp_block|
+          iblk = zone.add_element 'icmp-block'
+          iblk.add_attribute('name', icmp_block)
+        end
+      end
+
+      if @resource[:masquerade]
+        if @resource[:masquerade].at(0).to_s == 'true'
+          zone.add_element 'masquerade'
+        end
+      end
+
+      if @resource[:forward_ports]
+        @resource[:forward_ports].each do |forward_port|
+          fw_prt = zone.add_element 'forward-port'
+          fw_prt.add_attribute('port', forward_port['port'])
+          fw_prt.add_attribute('protocol', forward_port['protocol'])
+          if forward_port['to_port']
+            fw_prt.add_attribute('to-port', forward_port['to_port'])
+          end
+          if forward_port['to_addr']
+            fw_prt.add_attribute('to-addr', forward_port['to_addr'])
           end
         end
+      end
 
-        if @resource[:sources]
-          @resource[:sources].each do |source|
-            # TODO: firewall-cmd --get-zone-of-source...
-            src = zone.add_element 'source'
-            src.add_attribute('address', source)
+      if @resource[:rich_rules]
+        @resource[:rich_rules].each do |rich_rule|
+          rule = zone.add_element 'rule'
+          if rich_rule['family']
+            rule.add_attribute('family', rich_rule['family'])
           end
-        end
 
-        if @resource[:services]
-          @resource[:services].each do |service|
-            srv = zone.add_element 'service'
-            srv.add_attribute('name', service)
-            Puppet.debug "firewalld zone provider: adding service (#{service}) to zone"
+          if rich_rule['source']
+            source = rule.add_element 'source'
+            source.add_attribute('address', rich_rule['source']['address'])
+            source.add_attribute('invert', rich_rule['source']['invert'])
           end
-        end
 
-        if @resource[:ports]
-          @resource[:ports].each do |port|
-            prt = zone.add_element 'port'
-            prt.add_attribute('port', port['port'])
-            prt.add_attribute('protocol', port['protocol'])
+          if rich_rule['destination']
+            dest = rule.add_element 'destination'
+            dest.add_attribute('address', rich_rule['destination']['address'])
+            dest.add_attribute('invert', rich_rule['destination']['invert'])
           end
-        end
 
-        if @resource[:icmp_blocks]
-          @resource[:icmp_blocks].each do |icmp_block|
-            iblk = zone.add_element 'icmp-block'
-            iblk.add_attribute('name', icmp_block)
+          if rich_rule['service']
+            service = rule.add_element 'service'
+            service.add_attribute('name', rich_rule['service'])
           end
-        end
 
-        if @resource[:masquerade]
-          if @resource[:masquerade].at(0).to_s == 'true'
-            zone.add_element 'masquerade'
+          if rich_rule['port']
+            port = rule.add_element 'port'
+            port.add_attribute('port', rich_rule['port']['portid'])
+            port.add_attribute('protocol', rich_rule['port']['protocol'])
           end
-        end
 
-        if @resource[:forward_ports]
-          @resource[:forward_ports].each do |forward_port|
-            fw_prt = zone.add_element 'forward-port'
-            fw_prt.add_attribute('port', forward_port['port'])
-            fw_prt.add_attribute('protocol', forward_port['protocol'])
-            if forward_port['to_port']
-              fw_prt.add_attribute('to-port', forward_port['to_port'])
+          if rich_rule['protocol']
+            protocol = rule.add_element 'protocol'
+            protocol.add_attribute('value', rich_rule['protocol'])
+          end
+
+          if rich_rule['icmp_block']
+            icmp_block = rule.add_element 'icmp-block'
+            icmp_block.add_attribute('name', rich_rule['icmp_block'])
+          end
+
+          if rich_rule['masquerade']
+            rule.add_element 'masquerade'
+          end
+
+          if rich_rule['forward_port']
+            fw_port = rule.add_element 'forward-port'
+            fw_port.add_attribute('port', rich_rule['forward_port']['portid'])
+            fw_port.add_attribute('protocol', rich_rule['forward_port']['protocol'])
+            if rich_rule['forward_port']['to_port']
+              fw_port.add_attribute('to-port', rich_rule['forward_port']['to_port'])
             end
-            if forward_port['to_addr']
-              fw_prt.add_attribute('to-addr', forward_port['to_addr'])
+            if rich_rule['forward_port']['to_addr']
+              fw_port.add_attribute('to-addr', rich_rule['forward_port']['to_addr'])
             end
           end
-        end
 
-        if @resource[:rich_rules]
-          @resource[:rich_rules].each do |rich_rule|
-            rule = zone.add_element 'rule'
-            if rich_rule['family']
-              rule.add_attribute('family', rich_rule['family'])
+          if rich_rule['log']
+            log = rule.add_element 'log'
+            if rich_rule['log']['prefix']
+              log.add_attribute('prefix', rich_rule['log']['prefix'])
             end
-
-            if rich_rule['source']
-              source = rule.add_element 'source'
-              source.add_attribute('address', rich_rule['source']['address'])
-              source.add_attribute('invert', rich_rule['source']['invert'])
+            if rich_rule['log']['level']
+              log.add_attribute('level', rich_rule['log']['level'])
             end
-
-            if rich_rule['destination']
-              dest = rule.add_element 'destination'
-              dest.add_attribute('address', rich_rule['destination']['address'])
-              dest.add_attribute('invert', rich_rule['destination']['invert'])
+            if rich_rule['log']['limit']
+              limit = log.add_element 'limit'
+              limit.add_attribute('value', rich_rule['log']['limit'])
             end
+          end
 
-            if rich_rule['service']
-              service = rule.add_element 'service'
-              service.add_attribute('name', rich_rule['service'])
+          if rich_rule['audit']
+            audit = rule.add_element 'audit'
+            if rich_rule['audit']['limit']
+              limit = audit.add_element 'limit'
+              limit.add_attribute('value', rich_rule['audit']['limit'])
             end
+          end
 
-            if rich_rule['port']
-              port = rule.add_element 'port'
-              port.add_attribute('port', rich_rule['port']['portid'])
-              port.add_attribute('protocol', rich_rule['port']['protocol'])
+          if rich_rule['action']
+            action = rule.add_element rich_rule['action']['action_type']
+            if rich_rule['action']['reject_type']
+              action.add_attribute('type', rich_rule['action']['reject_type'])
             end
-
-            if rich_rule['protocol']
-              protocol = rule.add_element 'protocol'
-              protocol.add_attribute('value', rich_rule['protocol'])
-            end
-
-            if rich_rule['icmp_block']
-              icmp_block = rule.add_element 'icmp-block'
-              icmp_block.add_attribute('name', rich_rule['icmp_block'])
-            end
-
-            if rich_rule['masquerade']
-              rule.add_element 'masquerade'
-            end
-
-            if rich_rule['forward_port']
-              fw_port = rule.add_element 'forward-port'
-              fw_port.add_attribute('port', rich_rule['forward_port']['portid'])
-              fw_port.add_attribute('protocol', rich_rule['forward_port']['protocol'])
-              if rich_rule['forward_port']['to_port']
-                fw_port.add_attribute('to-port', rich_rule['forward_port']['to_port'])
-              end
-              if rich_rule['forward_port']['to_addr']
-                fw_port.add_attribute('to-addr', rich_rule['forward_port']['to_addr'])
-              end
-            end
-
-            if rich_rule['log']
-              log = rule.add_element 'log'
-              if rich_rule['log']['prefix']
-                log.add_attribute('prefix', rich_rule['log']['prefix'])
-              end
-              if rich_rule['log']['level']
-                log.add_attribute('level', rich_rule['log']['level'])
-              end
-              if rich_rule['log']['limit']
-                limit = log.add_element 'limit'
-                limit.add_attribute('value', rich_rule['log']['limit'])
-              end
-            end
-
-            if rich_rule['audit']
-              audit = rule.add_element 'audit'
-              if rich_rule['audit']['limit']
-                limit = audit.add_element 'limit'
-                limit.add_attribute('value', rich_rule['audit']['limit'])
-              end
-            end
-
-            if rich_rule['action']
-              action = rule.add_element rich_rule['action']['action_type']
-              if rich_rule['action']['reject_type']
-                action.add_attribute('type', rich_rule['action']['reject_type'])
-              end
-              if rich_rule['action']['limit']
-                limit = action.add_element 'limit'
-                limit.add_attribute('value', rich_rule['action']['limit'])
-              end
+            if rich_rule['action']['limit']
+              limit = action.add_element 'limit'
+              limit.add_attribute('value', rich_rule['action']['limit'])
             end
           end
         end
+      end
 
-        path = '/etc/firewalld/zones/' + @resource[:name] + '.xml'
-        file = File.open(path, "w+")
-	doc.write( file, 2 )
-        file.close
-        Puppet.debug "firewalld zone provider: Changes to #{path} configuration saved to disk."
-        firewall('--reload')
-        Puppet.debug "firewalld zone provider: reloading firewalld configuration"
-    end
+      path = '/etc/firewalld/zones/' + @resource[:name] + '.xml'
+      file = File.open(path, "w+")
+	    #doc.write( file, 2 )
+      fmt = REXML::Formatters::Pretty.new
+      fmt.compact = true
+      fmt.write(doc, file)
+      file.close
+      Puppet.debug "firewalld zone provider: Changes to #{path} configuration saved to disk."
+      #firewall('--reload')
+      #Puppet.debug "firewalld zone provider: reloading firewalld configuration"
+     # if @resource[:interfaces]
+     #   @resource[:interfaces].each do |interface|
+     # #    # TODO: firewall-cmd --get-zone-of-interface...
+     #     Puppet.debug "should be switching interface to zone..."
+     #     begin
+     #       zoneofinterface = exec_firewall('--get-zone-of-interface',interface)
+     #       puts zoneofinterface
+     #       #firewall('--permanent --zone='+zoneofinterface.strip+' --remove-interface='+interface)
+     #       if (zoneofinterface.strip != @resource[:name])
+     #         exec_firewall('--permanent','--zone',zoneofinterface.strip,'--remove-interface',interface)
+     #         exec_firewall('--zone',@resource[:name],'--change-interface',interface)
+     #       end
+     #     rescue Exception => bang
+     #       puts bang.message
+     #     end
+
+
+     #     #firewall('--permanent --zone='+@resource[:name]+' --change-interface='+interface)
+
+     #     #firewall('--zone=rcgtrusted --change-interface='+interface)
+     #     #firewall('--permanent --zone=rcgtrusted --change-interface='+interface)
+     # #    #iface = zone.add_element 'interface'
+     # #    #iface.add_attribute('name', interface)
+     #   end
+     # end
+  end
+
+  #Added by Adam
+  def exec_firewall(*extra_args)
+      args=[]
+      #args << '--permanent'
+      args << extra_args
+      args.flatten!
+      firewall(args)
+  end
+  #End of Added by Adam
 
   def self.instances
     debug "[instances]"
@@ -282,7 +337,13 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
             rule_log = {}
             rule_audit = {}
             rule_action = {}
-            rule_family = 'ipv4'
+            rule_family = ''
+
+          #Added by Adam
+          #if rule.attributes == 'family'
+            rule_family = e.attributes["family"].nil? ? nil : e.attributes["family"]
+          #end
+          #End of Added by Adam
 
           e.elements.each do |rule|
             if rule.name == 'source'
@@ -369,9 +430,9 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
               rule_action['reject_type'] = nil
               rule_action['limit']  = limit
             end
-            if rule.name == 'family'
-              rule_family = rule.attributes["type"].nil? ? nil : rule.attributes["family"]
-            end
+            #if rule.name == 'family'
+            #  rule_family = rule.attributes["family"].nil? ? nil : rule.attributes["family"]
+            #end
           end
           rich_rules << {
             'source'        => rule_source.empty? ? nil : rule_source,
@@ -394,7 +455,22 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
            rich_rules.each { |a| a.delete_if { |key,value| key == 'protocol' and value == nil} }
            rich_rules.each { |a| a.delete_if { |key,value| key == 'icmp_block' and value == nil} }
            rich_rules.each { |a| a.delete_if { |key,value| key == 'masquerade' and value == false} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'audit' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'log' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'destination' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'source' and value == nil} }
            rich_rules.each { |a| a.delete_if { |key,value| key == 'port' and value == nil} }
+           rich_rules.each { |a| a.delete_if { |key,value| key == 'family' and value == nil} }
+
+           rich_rules.each { |rr|
+             if rr["action"]
+               rr["action"].delete_if {|key,value| key == 'limit' and value == nil}
+               rr["action"].delete_if {|key,value| key == 'reject_type' and value == nil}
+             end
+             if rr["forward_port"]
+               rr["forward_port"].delete_if {|key,value| key == 'to_addr' and value == nil}
+             end
+           }
         end
 
       end

--- a/lib/puppet/provider/firewalld_zone/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zone/zoneprovider.rb
@@ -11,11 +11,13 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
   mk_resource_methods
 
   def flush
+      p "Flush property_hash is: #{@property_hash}"
       Puppet.debug "firewalld zone provider: flushing (#{@resource[:name]})"
       write_zonefile
   end
 
   def create
+      p "Create property_hash is: #{@property_hash}"
       Puppet.debug "firewalld zone provider: create (#{@resource[:name]})"
       write_zonefile
   end
@@ -26,7 +28,7 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
       zone = doc.add_element 'zone'
       doc << REXML::XMLDecl.new(version='1.0',encoding='utf-8')
 
-      if @resource[:target]
+      if @resource[:target] && ! @resource[:target].empty?
         zone.add_attribute('target', @resource[:target])
       end
 
@@ -250,6 +252,9 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
       target = root.attributes["target"]
       version = root.attributes["version"]
 
+      Puppet.debug("Target is: #{target}")
+
+
       # Loop through the zone elements
       doc.elements.each("zone/*") do |e|
 
@@ -442,6 +447,8 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
         masquerade = ["false"]
       end
 
+      Puppet.debug("Service is: #{service}")
+
       # Add hash to the zone array
       zone << new({
         :name          => zonename,
@@ -459,6 +466,7 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
         :forward_ports => forward_ports.empty? ? nil : forward_ports,
         :rich_rules    => rich_rules.empty? ? nil : rich_rules,
       })
+
     end
     zone
   end
@@ -467,10 +475,14 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
         path = '/etc/firewalld/zones' + @resource[:name] + '.xml'
         File.delete(path)
         Puppet.debug "firewalld zone provider: removing (#{path})"
+        p "Destroy property_hash is: #{@property_hash}"
         @property_hash.clear
     end
 
     def exists?
+        if resource[:target] == nil
+          resource[:target] = ''
+        end
         @property_hash[:ensure] == :present || false
     end
 end

--- a/lib/puppet/provider/firewalld_zone/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zone/zoneprovider.rb
@@ -45,7 +45,6 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
       if @resource[:interfaces]
         @resource[:interfaces].each do |interface|
           begin
-            Puppet.debug "should be switching zone of interface: " + interface
             zoneofinterface = exec_firewall('--get-zone-of-interface', interface)
             if (zoneofinterface.strip != @resource[:name])
               exec_firewall('--permanent', '--zone',zoneofinterface.strip, '--remove-interface', interface)
@@ -72,7 +71,6 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
         @resource[:services].each do |service|
           srv = zone.add_element 'service'
           srv.add_attribute('name', service)
-          Puppet.debug "firewalld zone provider: adding service (#{service}) to zone"
         end
       end
 
@@ -252,9 +250,6 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
       target = root.attributes["target"]
       version = root.attributes["version"]
 
-      Puppet.debug("Target is: #{target}")
-
-
       # Loop through the zone elements
       doc.elements.each("zone/*") do |e|
 
@@ -327,9 +322,9 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
             if rule.name == 'destination'
               rule_destination['address'] = rule.attributes["address"]
               if rule.attributes["invert"] == 'true'
-                rule_destination['invert'] = true
+                rule_destination['invert'] = 'true'
               else
-                rule_destination['invert'] = rule.attributes["invert"].nil? ? nil : false
+                rule_destination['invert'] = rule.attributes["invert"].nil? ? nil : 'false'
               end
               rule_destination.delete_if { |key,value| key == 'invert' and value == nil}
             end
@@ -446,8 +441,6 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
       else
         masquerade = ["false"]
       end
-
-      Puppet.debug("Service is: #{service}")
 
       # Add hash to the zone array
       zone << new({

--- a/lib/puppet/provider/firewalld_zone/zoneprovider.rb
+++ b/lib/puppet/provider/firewalld_zone/zoneprovider.rb
@@ -11,13 +11,11 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
   mk_resource_methods
 
   def flush
-      p "Flush property_hash is: #{@property_hash}"
       Puppet.debug "firewalld zone provider: flushing (#{@resource[:name]})"
       write_zonefile
   end
 
   def create
-      p "Create property_hash is: #{@property_hash}"
       Puppet.debug "firewalld zone provider: create (#{@resource[:name]})"
       write_zonefile
   end
@@ -468,7 +466,6 @@ Puppet::Type.type(:firewalld_zone).provide :zoneprovider, :parent => Puppet::Pro
         path = '/etc/firewalld/zones' + @resource[:name] + '.xml'
         File.delete(path)
         Puppet.debug "firewalld zone provider: removing (#{path})"
-        p "Destroy property_hash is: #{@property_hash}"
         @property_hash.clear
     end
 

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -73,6 +73,23 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
               limit       => string, optional
             }
       EOT
+
+      def insync?(is)
+        def itos(h)
+          h.each { |key, value|
+            h[key] = itos(value) if value.is_a?(Hash)
+            h[key] = value.to_s if value.is_a?(Integer)
+          }
+        end
+        if is.is_a?(Array) and @should.is_a?(Array)
+          @should.each { |should_el| 
+            itos(should_el) 
+            break unless is.detect { |is_el| is_el == should_el } 
+          }
+        else
+          is == @should
+        end
+      end
   end
 
 end

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -78,7 +78,21 @@ Puppet::Type.newtype(:firewalld_zone) do
       doesn't match any rule (port, service, etc.).
       Default (when target is not specified) is reject.
     EOT
-    newvalues('ACCEPT', '%%REJECT%%', 'DROP')
+    newvalues('ACCEPT', '%%REJECT%%', 'DROP', '')
+    def insync?(is)
+      self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+      if @should.empty? && is == :absent then
+        return true
+      end
+        
+      if match_all? then
+        return false unless is.is_a? Array
+        return false unless is.length == @should.length
+        return (is == @should or is == @should.map(&:to_s))
+      else
+        return @should.any? {|want| property_matches?(is, want) }
+      end
+    end
   end
 
   newproperty(:short) do
@@ -91,6 +105,20 @@ Puppet::Type.newtype(:firewalld_zone) do
 
   newproperty(:interfaces, :array_matching => :all) do
       desc "list of interfaces to bind to a zone"
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
   end
 
   newproperty(:sources, :array_matching => :all) do
@@ -98,6 +126,20 @@ Puppet::Type.newtype(:firewalld_zone) do
         list of source addresses or source address
         ranges ("address/mask") to bind to a zone
       EOT
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
   end
 
   newproperty(:ports, :array_matching => :all) do
@@ -111,21 +153,78 @@ Puppet::Type.newtype(:firewalld_zone) do
             ...
           ]
       EOT
-
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
+  
   end
 
   newproperty(:services, :array_matching => :all) do
       desc "list of predefined firewalld services"
+
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
   end
 
   newproperty(:icmp_blocks, :array_matching => :all) do
       desc "list of predefined icmp-types to block"
-  end
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
+   end
 
   newproperty(:masquerade, :array_matching => :all) do
       desc "enable masquerading ?"
       newvalues(:true, :false)
       defaultto false
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
   end
 
   newproperty(:forward_ports, :array_matching => :all) do
@@ -141,6 +240,20 @@ Puppet::Type.newtype(:firewalld_zone) do
             ...
           ]
       EOT
+      def insync?(is)
+        self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
+        if @should.empty? && is == :absent then
+          return true
+        end
+          
+        if match_all? then
+          return false unless is.is_a? Array
+          return false unless is.length == @should.length
+          return (is == @should or is == @should.map(&:to_s))
+        else
+          return @should.any? {|want| property_matches?(is, want) }
+        end
+      end
   end
 
   newproperty(:rich_rules, :array_matching => :all) do
@@ -198,7 +311,6 @@ Puppet::Type.newtype(:firewalld_zone) do
               limit       => string, optional
             }
       EOT
-
   end
 
 end

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -199,27 +199,6 @@ Puppet::Type.newtype(:firewalld_zone) do
             }
       EOT
 
-      #def insync?(is)
-      #  STDERR.puts "Should is #{@should}"
-      #  return true unless @should
-      #  # an empty array is analogous to no should values
-      #  return true if @should.empty?
-
-      #  def itos(h)
-      #    h.each { |key, value|
-      #      h[key] = itos(value) if value.is_a?(Hash)
-      #      h[key] = value.to_s if value.is_a?(Integer)
-      #    }
-      #  end
-      #  if is.is_a?(Array) and @should.is_a?(Array)
-      #    @should.each { |should_el|
-      #      itos(should_el)
-      #      break unless is.detect { |is_el| is_el == should_el }
-      #    }
-      #  else
-      #    is == @should
-      #  end
-      #end
   end
 
 end

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:firewalld_zone) do
     newvalues('ACCEPT', '%%REJECT%%', 'DROP', '')
     def insync?(is)
       self.devfail "#{self.class.name}'s should is not array" unless @should.is_a?(Array)
-      if @should.empty? && is == :absent then
+      if (@should.empty? || @should == ['']) && is == :absent then
         return true
       end
         

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -71,7 +71,7 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
   end 
 
-  newparam(:target) do
+  newproperty(:target) do
     desc <<-EOT
       Can be one of {'ACCEPT', '%%REJECT%%', 'DROP'}.
       Used to accept, reject or drop every packet that 
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:firewalld_zone) do
     newvalues('ACCEPT', '%%REJECT%%', 'DROP')
   end
 
-  newparam(:short) do
+  newproperty(:short) do
       desc "short readable name"
   end
 
@@ -198,6 +198,28 @@ Puppet::Type.newtype(:firewalld_zone) do
               limit       => string, optional
             }
       EOT
+
+      #def insync?(is)
+      #  STDERR.puts "Should is #{@should}"
+      #  return true unless @should
+      #  # an empty array is analogous to no should values
+      #  return true if @should.empty?
+
+      #  def itos(h)
+      #    h.each { |key, value|
+      #      h[key] = itos(value) if value.is_a?(Hash)
+      #      h[key] = value.to_s if value.is_a?(Integer)
+      #    }
+      #  end
+      #  if is.is_a?(Array) and @should.is_a?(Array)
+      #    @should.each { |should_el|
+      #      itos(should_el)
+      #      break unless is.detect { |is_el| is_el == should_el }
+      #    }
+      #  else
+      #    is == @should
+      #  end
+      #end
   end
 
 end

--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -38,7 +38,7 @@
 #   If set to 'yes', firewall changes with the D-Bus interface will be
 #   limited to applications that are listed in the lockdown whitelist.
 #   Default is 'no'
-# [*IPv6_rpfilter*]
+# [*ipv6_rpfilter*]
 #   Performs a reverse path filter test on a packet for IPv6. If a reply to
 #   the packet would be sent via the same interface that the packet arrived on,
 #   the packet will match and be accepted, otherwise dropped. Default is 'yes'.
@@ -53,7 +53,7 @@ class firewalld::configuration (
   $minimal_mark = '100',
   $cleanup_on_exit = 'yes',
   $lockdown = 'no',
-  $IPv6_rpfilter = 'yes',
+  $ipv6_rpfilter = 'yes',
 ) {
 
   include firewalld

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,16 @@ class firewalld {
   package { 'firewalld':
     ensure => present,  # install package
   }
+  if ($::operatingsystem == 'ubuntu' and $::operatingsystemmajrelease =~ /^15\.\d+$/) {
+    service { 'ufw':
+      ensure => stopped,
+      enable => false,
+    } ->
+    package { 'ufw':
+      ensure => absent
+    }
+  }
+
 
   # iptables service that comes with rhel/centos
   service { 'iptables':    # don't let this interfere

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@ class firewalld {
 
   exec{ 'firewalld::reload':
     path        =>'/usr/bin:/bin',
-    command     => 'firewall-cmd --complete-reload',
+    command     => 'firewall-cmd --reload',
     refreshonly => true,
   }
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -117,6 +117,7 @@
 #      },],}
 #
 define firewalld::zone(
+  $ensure = present,
   $target = undef,
   $short = '',
   $description = '',
@@ -132,23 +133,27 @@ define firewalld::zone(
 
   include firewalld::zone::base
   include firewalld::configuration
-
-  firewalld_zone { $name:
-    target        => $target,
-    short         => $short,
-    description   => $description,
-    interfaces    => $interfaces,
-    sources       => $sources,
-    ports         => $ports,
-    services      => $services,
-    icmp_blocks   => $icmp_blocks,
-    masquerade    => $masquerade,
-    forward_ports => $forward_ports,
-    rich_rules    => $rich_rules,
+  if $ensure == present {
+    firewalld_zone { $name:
+      target        => $target,
+      short         => $short,
+      description   => $description,
+      interfaces    => $interfaces,
+      sources       => $sources,
+      ports         => $ports,
+      services      => $services,
+      icmp_blocks   => $icmp_blocks,
+      masquerade    => $masquerade,
+      forward_ports => $forward_ports,
+      rich_rules    => $rich_rules,
+      notify        => Exec['firewalld::reload'],
+    }
   }
   #Ensure the zone file is present and not destroyed if purge_zones is set to true
+  #Also Ensure that the file can be set to absent and deleted if purge_zones is set to false
   file { "/etc/firewalld/zones/${name}.xml":
-    ensure  => present
+    ensure  => $ensure,
+    notify  => Exec['firewalld::reload'],
   }
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jpopelka-firewalld",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Jiri Popelka <jpopelka@redhat.com>",
   "summary": "Puppet Module for Firewalld",
   "license": "GPLv2+",
@@ -25,6 +25,12 @@
       "operatingsystemrelease": [
         "20",
         "21"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "15.04"
       ]
     }
   ],

--- a/templates/firewalld.conf.erb
+++ b/templates/firewalld.conf.erb
@@ -30,4 +30,4 @@ Lockdown=<%= @lockdown %>
 # packet will match and be accepted, otherwise dropped.
 # The rp_filter for IPv4 is controlled using sysctl.
 # Default: yes
-IPv6_rpfilter=<%= @IPv6_rpfilter %>
+IPv6_rpfilter=<%= @ipv6_rpfilter %>


### PR DESCRIPTION
I would definitely bump the version and maybe consider putting this to 1.0 
The rich rules manifest/method, if applying to a zone that you are trying to manage at the same time with the zone manifest/method, seems to cause it to submit a reload everytime as it notices a change due to 2 places making changes to the same item.  I have not fixed this, I do not currently use the functionality of adding rich_rules aside from zone.  Rather I do everything in one zone submission.
I have patched tonnes of issues and updated some functionality to make it very smooth, utilized --reload instead of --complete-reload as well to supposedly avoid any chance of dropped connections.  Also put in a lot of insync checks to make sure that if someone removes a line of code from their node manifest for the zone, it will actually notice it for array values, it didn't before.
I would recommend you look over all the changes for yourself but it should be satisfactory.  

As you will possibly also notice.  I updated the output of XML format for the zone file.  Comments are included in the code.  Fixes firewall-cmd issues and also may resolve one of the issues comments on this module in relation to to hiera with zone.xml and forward-port.  But I have not tested if it fixes that.

I also made it so that if you put an interface in or take it out of the puppet manifest for a zone then it will manage that AND run a change zone of interface permanent and immediate for that interface.  While still only running a reload on firewalld rather than needing to restart the whole service to support this.

FYI, this code also contains the code from koweblomke's #24  pull request as it seemed good to me, though I don't use it at this time.

I would also recommend you take a look at my additional addon module for firewalld: https://github.com/sfu-rcg/sfu_fwd - where I built a parser to allow people to submit rich_rules using arrays for their: source address, destination address, and services.  This allows for much less input by the user while it creates the rules for them using all possible combinations based off their specification ie. src add: ['1.1.1.1','2.2.2.2'], dst add: ['5.5.5.5','6.6.6.6'], svc: ['ssh','vnc-server']  would result in a few rules that look like: {src add: '1.1.1.1', dst add: '5.5.5.5', svc: 'ssh'} {src add: '1.1.1.1', dst add: '5.5.5.5', svc: 'vnc-server'} {src add: '1.1.1.1', dst add: '6.6.6.6', svc: 'ssh'} etc. etc.
Makes things much easier for an admin in my opinion if they have things like trusted networks that have multiple subnets.  Also built for supporting foreman via create_resources.

Feel free to ask me questions or comment on it.